### PR TITLE
Update runtime-version to 22.08

### DIFF
--- a/org.taisei_project.Taisei.yaml
+++ b/org.taisei_project.Taisei.yaml
@@ -1,6 +1,6 @@
 id: org.taisei_project.Taisei
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: taisei
 rename-icon: taisei


### PR DESCRIPTION
```
Info: runtime org.freedesktop.Platform branch 20.08 is end-of-life, with reason:
   org.freedesktop.Platform 20.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
```